### PR TITLE
Do not log ErrSmallBuffer for request headers unless LogAllErrors is set

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -17,7 +17,26 @@ import (
 	"github.com/erikdubbelboer/fasthttp/fasthttputil"
 )
 
-func TestServerErrSmallBuffer(t *testing.T) {
+func TestServerErrSmallBufferLogged(t *testing.T) {
+	logger := &customLogger{}
+	s := &Server{
+		Handler: func(ctx *RequestCtx) {
+			ctx.WriteString("shouldn't be never called")
+		},
+		ReadBufferSize: 20,
+		Logger:         logger,
+		LogAllErrors:   true,
+	}
+
+	testServerErrSmallBuffer(t, s, logger)
+
+	expectedErr := errSmallBuffer.Error()
+	if !strings.Contains(logger.out, expectedErr) {
+		t.Fatalf("unexpected log output: %q. Expecting %q", logger.out, expectedErr)
+	}
+}
+
+func TestServerErrSmallBufferNotLogged(t *testing.T) {
 	logger := &customLogger{}
 	s := &Server{
 		Handler: func(ctx *RequestCtx) {
@@ -26,6 +45,15 @@ func TestServerErrSmallBuffer(t *testing.T) {
 		ReadBufferSize: 20,
 		Logger:         logger,
 	}
+
+	testServerErrSmallBuffer(t, s, logger)
+
+	if len(logger.out) > 0 {
+		t.Fatalf("unexpected log output: %q. Expecting no output", logger.out)
+	}
+}
+
+func testServerErrSmallBuffer(t *testing.T, s *Server, logger *customLogger) {
 	ln := fasthttputil.NewInmemoryListener()
 
 	serverCh := make(chan error, 1)
@@ -87,11 +115,6 @@ func TestServerErrSmallBuffer(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected server error: %s. Server log: %q", err, logger.out)
 		}
-	}
-
-	expectedErr := errSmallBuffer.Error()
-	if !strings.Contains(logger.out, expectedErr) {
-		t.Fatalf("unexpected log output: %q. Expecting %q", logger.out, expectedErr)
 	}
 }
 

--- a/workerpool.go
+++ b/workerpool.go
@@ -209,9 +209,11 @@ func (wp *workerPool) workerFunc(ch *workerChan) {
 
 		if err = wp.WorkerFunc(c); err != nil && err != errHijacked {
 			errStr := err.Error()
-			if wp.LogAllErrors || !(strings.Contains(errStr, "broken pipe") ||
-				strings.Contains(errStr, "reset by peer") ||
-				strings.Contains(errStr, "i/o timeout")) {
+			if wp.LogAllErrors ||
+				!(strings.Contains(errStr, "broken pipe") ||
+					strings.Contains(errStr, "reset by peer") ||
+					strings.Contains(errStr, "i/o timeout") ||
+					strings.Contains(errStr, "request headers: small read buffer")) {
 				wp.Logger.Printf("error when serving connection %q<->%q: %s", c.LocalAddr(), c.RemoteAddr(), err)
 			}
 		}


### PR DESCRIPTION
fasthttp returns a 431 error when the request
headers are too large. Most other HTTP servers do not log an error when
the request header exceeds the limit. When serving HTTP requests
directly to browsers, it is normal to occasionally hit the limit due to
broken browsers or broken sites linking to your resource. These issues
are generally outside of your control in the same way the already
ignored errors are.

Note that ErrSmallBuffer _should_ always be logged for responses as this
should always be under your control.