### PR TITLE
Added PathNotFound handle func for handling 404.

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -105,11 +105,6 @@ var (
 	rootFSHandler RequestHandler
 )
 
-// PathNotFound fires when file is not found in filesystem
-// this functions tries to replace "Cannot open requested path"
-// server response giving to the programmer the control of server flow.
-type PathNotFoundFunc func(ctx *RequestCtx)
-
 // PathRewriteFunc must return new request path based on arbitrary ctx
 // info such as ctx.Path().
 //
@@ -246,11 +241,13 @@ type FS struct {
 	// By default request path is not modified.
 	PathRewrite PathRewriteFunc
 
-	// Path not found function.
+	// PathNotFound fires when file is not found in filesystem
+	// this functions tries to replace "Cannot open requested path"
+	// server response giving to the programmer the control of server flow.
 	//
 	// By default PathNotFound returns
 	// "Cannot open requested path"
-	PathNotFound PathNotFoundFunc
+	PathNotFound RequestHandler
 
 	// Expiration duration for inactive file handlers.
 	//
@@ -377,7 +374,7 @@ type fsHandler struct {
 	root                 string
 	indexNames           []string
 	pathRewrite          PathRewriteFunc
-	pathNotFound         PathNotFoundFunc
+	pathNotFound         RequestHandler
 	generateIndexPages   bool
 	compress             bool
 	acceptByteRange      bool

--- a/fs.go
+++ b/fs.go
@@ -105,6 +105,11 @@ var (
 	rootFSHandler RequestHandler
 )
 
+// PathNotFound fires when file is not found in filesystem
+// this functions tries to replace "Cannot open requested path"
+// server response giving to the programmer the control of server flow.
+type PathNotFoundFunc func(ctx *RequestCtx)
+
 // PathRewriteFunc must return new request path based on arbitrary ctx
 // info such as ctx.Path().
 //
@@ -241,6 +246,12 @@ type FS struct {
 	// By default request path is not modified.
 	PathRewrite PathRewriteFunc
 
+	// Path not found function.
+	//
+	// By default PathNotFound returns
+	// "Cannot open requested path"
+	PathNotFound PathNotFoundFunc
+
 	// Expiration duration for inactive file handlers.
 	//
 	// FSHandlerCacheDuration is used by default.
@@ -343,6 +354,7 @@ func (fs *FS) initRequestHandler() {
 		pathRewrite:          fs.PathRewrite,
 		generateIndexPages:   fs.GenerateIndexPages,
 		compress:             fs.Compress,
+		pathNotFound:         fs.PathNotFound,
 		acceptByteRange:      fs.AcceptByteRange,
 		cacheDuration:        cacheDuration,
 		compressedFileSuffix: compressedFileSuffix,
@@ -365,6 +377,7 @@ type fsHandler struct {
 	root                 string
 	indexNames           []string
 	pathRewrite          PathRewriteFunc
+	pathNotFound         PathNotFoundFunc
 	generateIndexPages   bool
 	compress             bool
 	acceptByteRange      bool
@@ -726,7 +739,12 @@ func (h *fsHandler) handleRequest(ctx *RequestCtx) {
 			}
 		} else if err != nil {
 			ctx.Logger().Printf("cannot open file %q: %s", filePath, err)
-			ctx.Error("Cannot open requested path", StatusNotFound)
+			if h.pathNotFound == nil {
+				ctx.Error("Cannot open requested path", StatusNotFound)
+			} else {
+				h.pathNotFound(ctx)
+				ctx.SetStatusCode(StatusNotFound)
+			}
 			return
 		}
 

--- a/fs_test.go
+++ b/fs_test.go
@@ -53,6 +53,43 @@ func TestNewVHostPathRewriterMaliciousHost(t *testing.T) {
 	}
 }
 
+func testPathNotFound(t *testing.T, pathNotFoundFunc PathNotFoundFunc) {
+	var ctx RequestCtx
+	var req Request
+	req.SetRequestURI("http//some.url/file")
+	ctx.Init(&req, nil, nil)
+
+	fs := &FS{
+		Root:         "./",
+		PathNotFound: pathNotFoundFunc,
+	}
+	fs.NewRequestHandler()(&ctx)
+
+	if pathNotFoundFunc == nil {
+		// different to ...
+		if !bytes.Equal(ctx.Response.Body(),
+			[]byte("Cannot open requested path")) {
+			t.Fatalf("response defers. Response: %q", ctx.Response.Body())
+		}
+	} else {
+		// Equals to ...
+		if bytes.Equal(ctx.Response.Body(),
+			[]byte("Cannot open requested path")) {
+			t.Fatalf("respones defers. Response: %q", ctx.Response.Body())
+		}
+	}
+}
+
+func TestPathNotFound(t *testing.T) {
+	testPathNotFound(t, nil)
+}
+
+func TestPathNotFoundFunc(t *testing.T) {
+	testPathNotFound(t, func(ctx *RequestCtx) {
+		ctx.WriteString("Not found hehe")
+	})
+}
+
 func TestServeFileHead(t *testing.T) {
 	var ctx RequestCtx
 	var req Request

--- a/fs_test.go
+++ b/fs_test.go
@@ -53,7 +53,7 @@ func TestNewVHostPathRewriterMaliciousHost(t *testing.T) {
 	}
 }
 
-func testPathNotFound(t *testing.T, pathNotFoundFunc PathNotFoundFunc) {
+func testPathNotFound(t *testing.T, pathNotFoundFunc RequestHandler) {
 	var ctx RequestCtx
 	var req Request
 	req.SetRequestURI("http//some.url/file")


### PR DESCRIPTION
When the filesystem does not find any file or directory in requested path, this function will give the programmer the possibility to handle this error. After this, the server will send a 404 code.