### PR TITLE
fix RawHeaders for POST

### DIFF
--- a/header.go
+++ b/header.go
@@ -1620,6 +1620,7 @@ func (h *RequestHeader) parse(buf []byte) (int, error) {
 		if err != nil {
 			return 0, err
 		}
+		h.rawHeaders = buf[m : m+n]
 		h.rawHeadersParsed = true
 	} else {
 		var rawHeaders []byte
@@ -1870,8 +1871,7 @@ func (h *RequestHeader) parseHeaders(buf []byte) (int, error) {
 		v := peekArgBytes(h.h, strConnection)
 		h.connectionClose = !hasHeaderValue(v, strKeepAlive) && !hasHeaderValue(v, strKeepAliveCamelCase)
 	}
-
-	return len(buf) - len(s.b), nil
+	return s.hLen, nil
 }
 
 func (h *RequestHeader) parseRawHeaders() {
@@ -1922,6 +1922,9 @@ type headerScanner struct {
 	value []byte
 	err   error
 
+	// hLen stores header subslice len
+	hLen int
+
 	disableNormalizing bool
 }
 
@@ -1929,10 +1932,12 @@ func (s *headerScanner) next() bool {
 	bLen := len(s.b)
 	if bLen >= 2 && s.b[0] == '\r' && s.b[1] == '\n' {
 		s.b = s.b[2:]
+		s.hLen += 2
 		return false
 	}
 	if bLen >= 1 && s.b[0] == '\n' {
 		s.b = s.b[1:]
+		s.hLen++
 		return false
 	}
 	n := bytes.IndexByte(s.b, ':')
@@ -1946,6 +1951,7 @@ func (s *headerScanner) next() bool {
 	for len(s.b) > n && s.b[n] == ' ' {
 		n++
 	}
+	s.hLen += n
 	s.b = s.b[n:]
 	n = bytes.IndexByte(s.b, '\n')
 	if n < 0 {
@@ -1953,6 +1959,7 @@ func (s *headerScanner) next() bool {
 		return false
 	}
 	s.value = s.b[:n]
+	s.hLen += n + 1
 	s.b = s.b[n+1:]
 
 	if n > 0 && s.value[n-1] == '\r' {

--- a/header.go
+++ b/header.go
@@ -1620,7 +1620,7 @@ func (h *RequestHeader) parse(buf []byte) (int, error) {
 		if err != nil {
 			return 0, err
 		}
-		h.rawHeaders = buf[m : m+n]
+		h.rawHeaders = append(h.rawHeaders[:0], buf[m:m+n]...)
 		h.rawHeadersParsed = true
 	} else {
 		var rawHeaders []byte

--- a/header_test.go
+++ b/header_test.go
@@ -135,27 +135,36 @@ func TestRequestRawHeaders(t *testing.T) {
 			t.Fatalf("expected header %q, got %q", exp, raw)
 		}
 	})
-	t.Run("post", func(t *testing.T) {
-		s := "POST / HTTP/1.1\r\n" + kvs + "body"
-		exp := "Host: foobar\r\n" +
-			"Value: b\r\n" +
-			"\r\n"
-		var h RequestHeader
-		br := bufio.NewReader(bytes.NewBufferString(s))
-		if err := h.Read(br); err != nil {
-			t.Fatalf("unexpected error: %s", err)
-		}
-		if string(h.Host()) != "foobar" {
-			t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), "foobar")
-		}
-		v2 := h.Peek("Value")
-		if !bytes.Equal(v2, []byte{'b'}) {
-			t.Fatalf("expecting non empty value. Got %q", v2)
-		}
-		if raw := h.RawHeaders(); string(raw) != exp {
-			t.Fatalf("expected header %q, got %q", exp, raw)
-		}
-	})
+	for _, n := range []int{0, 1, 4, 8} {
+		t.Run(fmt.Sprintf("post-%dk", n), func(t *testing.T) {
+			l := 1024 * n
+			body := make([]byte, l)
+			for i := range body {
+				body[i] = 'a'
+			}
+			cl := fmt.Sprintf("Content-Length: %d\r\n", l)
+			s := "POST / HTTP/1.1\r\n" + cl + kvs + string(body)
+			exp := cl +
+				"Host: foobar\r\n" +
+				"Value: b\r\n" +
+				"\r\n"
+			var h RequestHeader
+			br := bufio.NewReader(bytes.NewBufferString(s))
+			if err := h.Read(br); err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if string(h.Host()) != "foobar" {
+				t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), "foobar")
+			}
+			v2 := h.Peek("Value")
+			if !bytes.Equal(v2, []byte{'b'}) {
+				t.Fatalf("expecting non empty value. Got %q", v2)
+			}
+			if raw := h.RawHeaders(); string(raw) != exp {
+				t.Fatalf("expected header %q, got %q", exp, raw)
+			}
+		})
+	}
 	t.Run("http10", func(t *testing.T) {
 		s := "GET / HTTP/1.0\r\n" + kvs
 		exp := "Host: foobar\r\n" +

--- a/header_test.go
+++ b/header_test.go
@@ -111,14 +111,12 @@ func TestRequestHeaderEmptyValueFromString(t *testing.T) {
 }
 
 func TestRequestRawHeaders(t *testing.T) {
-	kvs := "EmptyValue:\r\n" +
-		"host: foobar\r\n" +
+	kvs := "host: foobar\r\n" +
 		"value: b\r\n" +
 		"\r\n"
 	t.Run("normalized", func(t *testing.T) {
 		s := "GET / HTTP/1.1\r\n" + kvs
-		exp := "Emptyvalue:\r\n" +
-			"Host: foobar\r\n" +
+		exp := "Host: foobar\r\n" +
 			"Value: b\r\n" +
 			"\r\n"
 		var h RequestHeader
@@ -129,16 +127,54 @@ func TestRequestRawHeaders(t *testing.T) {
 		if string(h.Host()) != "foobar" {
 			t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), "foobar")
 		}
-		v1 := h.Peek("EmptyValue")
-		if len(v1) > 0 {
-			t.Fatalf("expecting empty value. Got %q", v1)
+		v2 := h.Peek("Value")
+		if !bytes.Equal(v2, []byte{'b'}) {
+			t.Fatalf("expecting non empty value. Got %q", v2)
+		}
+		if raw := h.RawHeaders(); string(raw) != exp {
+			t.Fatalf("expected header %q, got %q", exp, raw)
+		}
+	})
+	t.Run("post", func(t *testing.T) {
+		s := "POST / HTTP/1.1\r\n" + kvs + "body"
+		exp := "Host: foobar\r\n" +
+			"Value: b\r\n" +
+			"\r\n"
+		var h RequestHeader
+		br := bufio.NewReader(bytes.NewBufferString(s))
+		if err := h.Read(br); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if string(h.Host()) != "foobar" {
+			t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), "foobar")
 		}
 		v2 := h.Peek("Value")
 		if !bytes.Equal(v2, []byte{'b'}) {
 			t.Fatalf("expecting non empty value. Got %q", v2)
 		}
 		if raw := h.RawHeaders(); string(raw) != exp {
-			t.Fatalf("unexpected raw header %q, expected %q instead", kvs, raw)
+			t.Fatalf("expected header %q, got %q", exp, raw)
+		}
+	})
+	t.Run("http10", func(t *testing.T) {
+		s := "GET / HTTP/1.0\r\n" + kvs
+		exp := "Host: foobar\r\n" +
+			"Value: b\r\n" +
+			"\r\n"
+		var h RequestHeader
+		br := bufio.NewReader(bytes.NewBufferString(s))
+		if err := h.Read(br); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if string(h.Host()) != "foobar" {
+			t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), "foobar")
+		}
+		v2 := h.Peek("Value")
+		if !bytes.Equal(v2, []byte{'b'}) {
+			t.Fatalf("expecting non empty value. Got %q", v2)
+		}
+		if raw := h.RawHeaders(); string(raw) != exp {
+			t.Fatalf("expected header %q, got %q", exp, raw)
 		}
 	})
 	t.Run("non-normalized", func(t *testing.T) {
@@ -153,16 +189,12 @@ func TestRequestRawHeaders(t *testing.T) {
 		if string(h.Host()) != "" {
 			t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), "")
 		}
-		v1 := h.Peek("EmptyValue")
-		if len(v1) > 0 {
-			t.Fatalf("expecting empty value. Got %q", v1)
-		}
 		v2 := h.Peek("value")
 		if !bytes.Equal(v2, []byte{'b'}) {
 			t.Fatalf("expecting non empty value. Got %q", v2)
 		}
 		if raw := h.RawHeaders(); string(raw) != exp {
-			t.Fatalf("unexpected raw header %q, expected %q instead", kvs, raw)
+			t.Fatalf("expected header %q, got %q", exp, raw)
 		}
 	})
 	t.Run("no-kvs", func(t *testing.T) {
@@ -182,7 +214,7 @@ func TestRequestRawHeaders(t *testing.T) {
 			t.Fatalf("expecting empty value. Got %q", v1)
 		}
 		if raw := h.RawHeaders(); string(raw) != exp {
-			t.Fatalf("unexpected raw header %q, expected %q instead", kvs, raw)
+			t.Fatalf("expected header %q, got %q", exp, raw)
 		}
 	})
 }


### PR DESCRIPTION
I'm sorry for the hassle, but apparently fhttp has fast path header parser for HEAD and GET and `rawHeaders` isn't properly set for other methods. This PR is a fix to #27.

- L1623 now assigns `rawHeaders` to a proper sub-slice for methods with possible body.
- parseHeaders() wasn't returning proper "length parsed", this is fixed by adding internal accumulator in `headerScanner` to properly return parsed length.
- added tests to cover POST and HTTP1.0 cases.

Admittedly this affects global hot path, but any difference is lost in noise:
```sh
# 10 runs of each
name                       old time/op  new time/op  delta
ServerGet10KReqPerConn-8    627ns ± 1%   635ns ± 2%  +1.33%  (p=0.026 n=9+10)
ServerPost10KReqPerConn-8   702ns ± 9%   699ns ± 6%    ~     (p=0.825 n=10+9)
```

Intuitively, one int counter doesn't change much.