### PR TITLE
Store raw headers aside to avoid mutation

### DIFF
--- a/header_test.go
+++ b/header_test.go
@@ -116,9 +116,7 @@ func TestRequestRawHeaders(t *testing.T) {
 		"\r\n"
 	t.Run("normalized", func(t *testing.T) {
 		s := "GET / HTTP/1.1\r\n" + kvs
-		exp := "Host: foobar\r\n" +
-			"Value: b\r\n" +
-			"\r\n"
+		exp := kvs
 		var h RequestHeader
 		br := bufio.NewReader(bytes.NewBufferString(s))
 		if err := h.Read(br); err != nil {
@@ -144,10 +142,7 @@ func TestRequestRawHeaders(t *testing.T) {
 			}
 			cl := fmt.Sprintf("Content-Length: %d\r\n", l)
 			s := "POST / HTTP/1.1\r\n" + cl + kvs + string(body)
-			exp := cl +
-				"Host: foobar\r\n" +
-				"Value: b\r\n" +
-				"\r\n"
+			exp := cl + kvs
 			var h RequestHeader
 			br := bufio.NewReader(bytes.NewBufferString(s))
 			if err := h.Read(br); err != nil {
@@ -167,9 +162,7 @@ func TestRequestRawHeaders(t *testing.T) {
 	}
 	t.Run("http10", func(t *testing.T) {
 		s := "GET / HTTP/1.0\r\n" + kvs
-		exp := "Host: foobar\r\n" +
-			"Value: b\r\n" +
-			"\r\n"
+		exp := kvs
 		var h RequestHeader
 		br := bufio.NewReader(bytes.NewBufferString(s))
 		if err := h.Read(br); err != nil {


### PR DESCRIPTION
My previous contribution led to a case where RawHeader() return is affected by normalization. If normalization is turned off, things like Content-Length get broken.

This patch makes a copy of raw headers to guarantee the RawHeader() contract is unaffected by normalization switch.

Amortized, the performance hit is negligible:

```sh
name                       old time/op    new time/op    delta
ServerPost10KReqPerConn-8     320ns ± 2%     338ns ± 7%  +5.49%  (p=0.003 n=5+10)

name                       old alloc/op   new alloc/op   delta
ServerPost10KReqPerConn-8     0.00B          0.00B         ~     (all equal)

name                       old allocs/op  new allocs/op  delta
ServerPost10KReqPerConn-8      0.00           0.00         ~     (all equal)
```