### PR TITLE
handle 't' and 'true' as bool in QueryArgs

### DIFF
--- a/args.go
+++ b/args.go
@@ -288,7 +288,7 @@ func (a *Args) GetUfloatOrZero(key string) float64 {
 
 // GetBool returns boolean value for the given key.
 //
-// true is returned for '1', 'y' and 'yes' values,
+// true is returned for '1', 'y', 'yes', 'true', 't' and also their UPPERCASE analogs values,
 // otherwise false is returned.
 func (a *Args) GetBool(key string) bool {
 	switch strings.ToLower(string(a.Peek(key))) {

--- a/args.go
+++ b/args.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"sync"
+	"strings"
 )
 
 // AcquireArgs returns an empty Args object from the pool.
@@ -290,8 +291,8 @@ func (a *Args) GetUfloatOrZero(key string) float64 {
 // true is returned for '1', 'y' and 'yes' values,
 // otherwise false is returned.
 func (a *Args) GetBool(key string) bool {
-	switch string(a.Peek(key)) {
-	case "1", "y", "yes":
+	switch strings.ToLower(string(a.Peek(key))) {
+	case "1", "y", "yes", "true", "t":
 		return true
 	default:
 		return false


### PR DESCRIPTION
Hello!
Some people wants "t" and "true" and their uppercase analogs (T and TRUE) to be processed as bool value true
P.S. May be unexpected that, for example, GET http://example.com?a=true a will be false